### PR TITLE
Added rules for docker-build and docker-push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+## THIS EXPECTS TO BE INVOKED AFTER A TAR BUILD.
+## USE 'java -cp tools/tablesaw-1.2.4.jar make docker-image'
+## TO BUILD.
+
+FROM java:openjdk-8
+
+ARG VERSION
+
+ADD build/kairosdb-${VERSION}.tar /root/
+
+WORKDIR /root/kairosdb
+
+CMD ["/root/kairosdb/bin/kairosdb.sh", "run"]
+
+# Kairos API telnet and jetty ports
+EXPOSE 4242 8083
+
+LABEL maintainer="brianhks1+kairos@gmail.com" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.name="kairosdb" \
+      org.label-schema.description="Test version for kairosdb" \
+      org.label-schema.docker.dockerfile="/Dockerfile"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ FROM java:openjdk-8
 
 ARG VERSION
 
-ADD build/kairosdb-${VERSION}.tar /root/
+ADD build/kairosdb-${VERSION}.tar /opt/
 
-WORKDIR /root/kairosdb
+WORKDIR /opt/kairosdb
 
-CMD ["/root/kairosdb/bin/kairosdb.sh", "run"]
+CMD ["/opt/kairosdb/bin/kairosdb.sh", "run"]
 
 # Kairos API telnet and jetty ports
 EXPOSE 4242 8083

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,8 @@ EXPOSE 4242 8083
 LABEL maintainer="brianhks1+kairos@gmail.com" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.name="kairosdb" \
-      org.label-schema.description="Test version for kairosdb" \
+      org.label-schema.description="KairosDB is a time series database that stores numeric values along\
+ with key/value tags to a nosql data store.  Currently supported\
+ backends are Cassandra and H2.  An H2 implementation is provided\
+ for development work." \
       org.label-schema.docker.dockerfile="/Dockerfile"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ## USE 'java -cp tools/tablesaw-1.2.4.jar make docker-image'
 ## TO BUILD.
 
-FROM java:openjdk-8
+FROM openjdk:8u151
 
 ARG VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ FROM openjdk:8u151
 
 ARG VERSION
 
+RUN useradd -M kairosdb
+
 ADD build/kairosdb-${VERSION}.tar /opt/
+
+RUN chown -R kairosdb /opt/kairosdb
 
 WORKDIR /opt/kairosdb
 
@@ -14,6 +18,8 @@ CMD ["/opt/kairosdb/bin/kairosdb.sh", "run"]
 
 # Kairos API telnet and jetty ports
 EXPOSE 4242 8083
+
+USER kairosdb
 
 LABEL maintainer="brianhks1+kairos@gmail.com" \
       org.label-schema.schema-version="1.0" \

--- a/build.groovy
+++ b/build.groovy
@@ -510,13 +510,12 @@ def doDockerBuild(Rule rule)
 
 def getDockerTag()
 {
-  env = System.getenv()
 
-  def registry = ""
-  
-  if ( env.containsKey("DOCKER_REGISTRY") ) {
-    registry = env.get("DOCKER_REGISTRY") + "/"
-  }
+	def registry = saw.getProperty("DOCKER_REGISTRY", "");
+
+	if ( registry != "" ) {
+		registry += "/"
+	}
 
   return registry + "${programName}:${version}-${release}"
 

--- a/build.groovy
+++ b/build.groovy
@@ -498,40 +498,36 @@ def doDocs(Rule rule)
 //---------------------------------------------------------------------------
 //Build container
 dockerBuild = new SimpleRule("docker-build").setDescription("Build a Docker image")
-.addDepend(tarRule)
-.setMakeAction("doDockerBuild")
+        .addDepend(tarRule)
+        .setMakeAction("doDockerBuild")
 
-def doDockerBuild(Rule rule)
-{
-  def tag = getDockerTag()
-  command = "docker build -t ${tag} --build-arg VERSION=${version}-${release} ."
-  saw.exec(command)
+def doDockerBuild(Rule rule) {
+    def tag = getDockerTag()
+    command = "docker build -t ${tag} --build-arg VERSION=${version}-${release} ."
+    saw.exec(command)
 }
 
-def getDockerTag()
-{
+def getDockerTag() {
+    def registry = saw.getProperty("DOCKER_REGISTRY", "");
 
-	def registry = saw.getProperty("DOCKER_REGISTRY", "");
+    if (registry != "") {
+        registry += "/"
+    }
 
-	if ( registry != "" ) {
-		registry += "/"
-	}
-
-  return registry + "${programName}:${version}-${release}"
+    return registry + "${programName}:${version}-${release}"
 
 }
 
 //------------------------------------------------------------------------------
 // Push container
 new SimpleRule("docker-push").setDescription("Push a Docker image to registry")
-.addDepend(dockerBuild)
-.setMakeAction("doDockerPush")
+        .addDepend(dockerBuild)
+        .setMakeAction("doDockerPush")
 
-def doDockerPush(Rule rule)
-{
-  def tag = getDockerTag()
-  command = "docker push ${tag}"
-  saw.exec(command)
+def doDockerPush(Rule rule) {
+    def tag = getDockerTag()
+    command = "docker push ${tag}"
+    saw.exec(command)
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
To make it easier to create a Docker image and push it from the build, I added a Dockerfile and a build rule ('docker-build') that automatically creates the image from it and tags it with the correct version number. You can specify a particular Docker registry and prefix by setting the DOCKER_REGISTRY environment variable. There's also a 'docker-push' rule that does a 'docker push' after a build.