### PR TITLE
Query source IP logging

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -1,6 +1,6 @@
 
 <ivy-module version="2.0">
-	<info organisation="kairosd.org" module="kairosdb"/>
+	<info organisation="kairosdb.org" module="kairosdb"/>
 	<configurations defaultconf="default" >
 		<conf name="default"/>
 		<conf name="integration" extends="test"/>

--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -81,6 +81,7 @@ enum ServerType
 public class MetricsResource implements KairosMetricReporter
 {
 	public static final Logger logger = LoggerFactory.getLogger(MetricsResource.class);
+	public static final Logger querySourceIPLogger = LoggerFactory.getLogger("query_source_ip_logger");
 	public static final String QUERY_TIME = "kairosdb.http.query_time";
 	public static final String REQUEST_TIME = "kairosdb.http.request_time";
 	public static final String INGEST_COUNT = "kairosdb.http.ingest_count";
@@ -164,6 +165,9 @@ public class MetricsResource implements KairosMetricReporter
 		logger.info("KairosDB server type set to: " + m_serverType.toString());
 	}
 
+	@Inject(optional = true)
+	@Named("kairosdb.queries.log_source_ip")
+	private boolean m_logQuerySourceIP = false;
 
 	@Inject
 	private SimpleStatsReporter m_simpleStatsReporter = new SimpleStatsReporter();
@@ -515,6 +519,7 @@ public class MetricsResource implements KairosMetricReporter
 			mainQuery.getEndAbsolute();
 
 			List<QueryMetric> queries = mainQuery.getQueryMetrics();
+			StringBuilder sourceIPLog = new StringBuilder("Query source IP: " + remoteAddr + "\tQuery metrics: ");
 
 			int queryCount = 0;
 			for (QueryMetric query : queries)
@@ -522,6 +527,8 @@ public class MetricsResource implements KairosMetricReporter
 				queryCount++;
 				ThreadReporter.addTag("metric_name", query.getName());
 				ThreadReporter.addTag("query_index", String.valueOf(queryCount));
+
+				sourceIPLog.append(query.getName() + ", ");
 
 				DatastoreQuery dq = datastore.createQuery(query);
 				long startQuery = System.currentTimeMillis();
@@ -543,6 +550,10 @@ public class MetricsResource implements KairosMetricReporter
 			writer.flush();
 			writer.close();
 
+			if (m_logQuerySourceIP)
+			{
+				querySourceIPLogger.info(sourceIPLog.substring(0, sourceIPLog.length() - 2));
+			}
 
 			//System.out.println("About to process plugins");
 			List<QueryPlugin> plugins = mainQuery.getPlugins();

--- a/src/main/resources/kairosdb.conf
+++ b/src/main/resources/kairosdb.conf
@@ -350,6 +350,10 @@ kairosdb: {
 	#and need a way to identify responses.
 	queries.return_query_in_response = false
 
+	# When set to true Kairos will log the source IP of incoming queries along with the
+	# metrics queried to a separate log file called query-src-ip.log
+	queries.log_source_ip = false
+
 	#===============================================================================
 	# Health Checks
 	service.health: "org.kairosdb.core.health.HealthCheckModule"

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -245,6 +245,10 @@ kairosdb.log.queries.greater_than=60
 # from inserting data witch each query
 kairosdb.queries.aggregate_stats=false
 
+# When set to true Kairos will log the source IP of incoming queries along with the
+# metrics queried to a separate log file called query-src-ip.log
+kairosdb.queries.log_source_ip = false
+
 #===============================================================================
 # Health Checks
 kairosdb.service.health=org.kairosdb.core.health.HealthCheckModule

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -61,6 +61,32 @@
 		</encoder>
 	</appender>
 
+	<!-- This appender is for logging the source IP address for queries that come in along with the metrics queried -->
+	<appender name="query_source_ip_data" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<file>log/query-src-ip.log</file>
+		<filter class="ch.qos.logback.classic.filter.LevelFilter">
+			<level>INFO</level>
+			<onMatch>ACCEPT</onMatch>
+			<onMismatch>DENY</onMismatch>
+		</filter>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<!-- daily rollover -->
+			<fileNamePattern>log/query-src-ip.%d.%i.log.gz</fileNamePattern>
+
+			<!-- keep 30 days' worth of history -->
+			<maxHistory>30</maxHistory>
+
+			<!-- or whenever the file size reaches 100MB -->
+			<timeBasedFileNamingAndTriggeringPolicy
+					class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+				<maxFileSize>100MB</maxFileSize>
+			</timeBasedFileNamingAndTriggeringPolicy>
+		</rollingPolicy>
+		<encoder>
+			<pattern>%d{MM-dd|HH:mm:ss.SSS} [%thread] %-5level [%file:%line] - %msg%n</pattern>
+		</encoder>
+	</appender>
+
 	<logger name="failed_logger" level="TRACE" additivity="true">
 		<appender-ref ref="failed_data"/>
 	</logger>
@@ -72,6 +98,10 @@
 	<!--Line below suppresses large amounts of info when users authenticate, comment to get it back -->
 	<logger name="org.eclipse.jetty.jaas.spi.LdapLoginModule" level="WARN"/>
 
+	<!-- This logger is for logging the source IP address for queries that come in along with the metrics queried -->
+	<logger name="query_source_ip_logger" level="INFO" additivity="false">
+		<appender-ref ref="query_source_ip_data"/>
+	</logger>
 
 	<!--<logger name="org.hbase.async.RegionClient" level="DEBUG"/>-->
 


### PR DESCRIPTION
- Added ability to log the source IP of queries along with the metrics being queried. When enabled they are logged to a separate log file, query-src-ip.log.
  - Log entry sample:
`12-09|11:22:23.972 [qtp90045638-59] INFO  [MetricsResource.java:555] - Query source IP: 127.0.0.1	Query metrics: kairosdb.jvm.free_memory, kairosdb.jvm.max_memory, kairosdb.datastore.query_row_count`
- Fixed a typo in ivy.xml.